### PR TITLE
POC subscribe form

### DIFF
--- a/src/components/footer/FooterForm.jsx
+++ b/src/components/footer/FooterForm.jsx
@@ -1,19 +1,38 @@
-import * as React from 'react';
+import { useState } from 'react';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
 import InputGroup from 'react-bootstrap/InputGroup';
 import AnimatedArrow from '../../assets/icons/animatedArrow';
+import {startSignup} from '../../shared/emailSubscriber/signupHelper';
 
 const FooterForm = () => {
+    const [emailValue, setEmailValue] = useState('');
+    const [signupResult, setSignupResult] = useState(null);
+    
+    
+    const applySignupResult = (result) =>{
+        console.log(result); // TODO delete me
+        setSignupResult(result);
+    }
+    
+    const handleSubmit = (event) => {
+        event.preventDefault();
+        if(emailValue !== ''){
+            startSignup(emailValue, applySignupResult);
+        }
+    };
+    
     return (
-        <Form className='pt-1'>
+        <Form className='pt-1' onSubmit={handleSubmit}>
             <InputGroup className="arrow-group mb-3 mt-4">
                 <Form.Control
                     type="email"
                     placeholder="Enter your email here"
                     aria-label="Your Email"
+                    value={emailValue}
+                    onChange={(e) => setEmailValue(e.target.value)}
                 />
-                <Button variant="primary" className='text-dark px-2'>
+                <Button variant="primary" className='text-dark px-2' type="submit">
                     <AnimatedArrow />
                 </Button>
             </InputGroup>

--- a/src/shared/emailSubscriber/signupHelper.ts
+++ b/src/shared/emailSubscriber/signupHelper.ts
@@ -1,0 +1,30 @@
+import { SignupResponse, SignupResult, SignupStatus } from "./types";
+import jsonp from "jsonp";
+
+const emailHost =
+  "https://kisslabs.us4.list-manage.com/subscribe/post-json?u=c1a5e982447e163b13590c489&amp;id=2c95acdcdd";
+
+const startSignup = (email: string, callback: any) => {
+  const url = `${emailHost}&email=${encodeURIComponent(email)}`;
+  jsonp(url, { param: "c" }, (err, data: SignupResponse) => {
+    const result: SignupResult = {
+      status: SignupStatus.error,
+      message: null,
+    };
+    if (data.msg.includes("already subscribed")) {
+      result.status = SignupStatus.duplicate;
+      result.message = data.msg;
+      console.warn(data.msg);
+    } else if (err) {
+      console.error(err);
+    } else if (data.result !== "success") {
+      console.error(data.msg);
+      result.message = data.msg;
+    } else {
+      result.status = SignupStatus.success;
+    }
+    callback(result);
+  });
+};
+
+export { startSignup };

--- a/src/shared/emailSubscriber/types.ts
+++ b/src/shared/emailSubscriber/types.ts
@@ -1,0 +1,14 @@
+export enum SignupStatus {
+  success,
+  duplicate,
+  error,
+}
+export interface SignupResult {
+  status: SignupStatus;
+  message: string | null;
+}
+
+export interface SignupResponse{
+  result: string;
+  msg: string;
+}


### PR DESCRIPTION
It allows signup to Mailchimp without backend using jsonp.
Callback `applySignupResult` in `FooterForm` get result 
```
SignupResult {
  status: SignupStatus;
  message: string | null;
}
```
which can be used further to update component 

The code is not fully tested because Mailchimp returns "Recipient \"\" has too many recent signup requests"
![image](https://github.com/pabrikushka/bit-project/assets/15932913/c98be4d6-4a9a-4feb-ab8e-a2239c56d78d)

It would be better to consider another option for that is using a backend, because:
- jsonp considered is not very safe
- looks like Mailchimp allows to sign up only using jsonp, other endpoints most likely require backend
- jsonp uses callback -> not perfect code

